### PR TITLE
Indicate to ember-cli that this addon should be "before" redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "minimatch": "^2.0.4"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": "ember-cli-deploy-redis"
   }
 }


### PR DESCRIPTION
Indicate to ember-cli that this addon should be "before" the redis plugin (if present).

Because both plugins implement the build hook, this will make it so that s3 runs before redis, and thus, that the assets are uploaded before the HTML that points to them.
