### PR TITLE
doen't use path.join for urls

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -37,7 +37,7 @@ module.exports = CoreObject.extend({
     var prefix       = options.prefix;
     var manifestPath = options.manifestPath;
     if (manifestPath) {
-      var key = path.join(prefix, manifestPath);
+      var key = prefix === '' ? manifestPath : [prefix, manifestPath].join('/');
       plugin.log('Downloading manifest for differential deploy from `' + key + '`...', { verbose: true });
       return new Promise(function(resolve, reject){
         var params = { Bucket: options.bucket, Key: key};
@@ -81,7 +81,7 @@ module.exports = CoreObject.extend({
       var data        = fs.readFileSync(basePath);
       var contentType = mime.lookup(basePath);
       var encoding    = mime.charsets.lookup(contentType);
-      var key         = path.join(prefix, filePath);
+      var key         = prefix === '' ? filePath : [prefix, filePath].join('/');
       var isGzipped   = gzippedFilePaths.indexOf(filePath) !== -1;
 
       if (encoding) {


### PR DESCRIPTION
The path module is for filesystem path. It is plaform agnostic and will add backslashs on windows. That is not the expected behavior.

I can not test it on windows, because I doen't have windows. And I'm not sure if the changed path in the `index-nodetest.js` is ok. Are leading Slashs OK for S3?
