### PR TITLE
Warn about configuration sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ For detailed information on what plugin hooks are and how they work, please refe
 
 For detailed information on how configuration of plugins works, please refer to the [Plugin Documentation][1].
 
+<hr/>
+**WARNING: Don't share a configuration object between [ember-cli-deploy-s3-index](https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index) and this plugin. The way these two plugins read their configuration has sideeffects which will unfortunately break your deploy if you share one configuration object between the two** (we are already working on a fix)
+<hr/>
+
 ### accessKeyId (`required`)
 
 The AWS access key for the user that has the ability to upload to the `bucket`.


### PR DESCRIPTION
Sharing a configuration object between the s3 plugin and s3-index break the deploy. We should warn about this until a fix lands
