### PR TITLE
Remove required keys, to support IAM roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,16 @@ For detailed information on how configuration of plugins works, please refer to 
 **WARNING: Don't share a configuration object between [ember-cli-deploy-s3-index](https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index) and this plugin. The way these two plugins read their configuration has sideeffects which will unfortunately break your deploy if you share one configuration object between the two** (we are already working on a fix)
 <hr/>
 
-### accessKeyId (`required`)
+### accessKeyId
 
-The AWS access key for the user that has the ability to upload to the `bucket`.
+The AWS access key for the user that has the ability to upload to the `bucket`. If this is left undefined, 
+the normal [AWS SDK credential resolution](5) will take place.
 
 *Default:* `undefined`
 
-### secretAccessKey (`required`)
+### secretAccessKey
 
-The AWS secret for the user that has the ability to upload to the `bucket`.
+The AWS secret for the user that has the ability to upload to the `bucket`. This must be defined when `accessKeyId` is defined.
 
 *Default:* `undefined`
 
@@ -166,3 +167,4 @@ The following properties are expected to be present on the deployment `context` 
 [2]: https://github.com/ember-cli-deploy/ember-cli-deploy-build "ember-cli-deploy-build"
 [3]: https://github.com/lukemelia/ember-cli-deploy-gzip "ember-cli-deploy-gzip"
 [4]: https://github.com/lukemelia/ember-cli-deploy-manifest "ember-cli-deploy-manifest"
+[5]: https://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials "Setting AWS Credentials"

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
           return context.s3Client; // if you want to provide your own S3 client to be used instead of one from aws-sdk
         }
       },
-      requiredConfig: ['accessKeyId', 'secretAccessKey', 'bucket', 'region'],
+      requiredConfig: ['bucket', 'region'],
 
       upload: function(context) {
         var self         = this;

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -14,11 +14,18 @@ module.exports = CoreObject.extend({
   init: function(options) {
     this._plugin = options.plugin;
     var AWS = require('aws-sdk');
-    this._client = this._plugin.readConfig('s3Client') || new AWS.S3({
-      accessKeyId: this._plugin.readConfig('accessKeyId'),
-      secretAccessKey: this._plugin.readConfig('secretAccessKey'),
+    var s3Options = {
       region: this._plugin.readConfig('region')
-    });
+    };
+    const accessKeyId = this._plugin.readConfig('accessKeyId');
+    const secretAccessKey = this._plugin.readConfig('secretAccessKey');
+
+    if (accessKeyId && secretAccessKey) {
+      this._plugin.log('Using AWS access key id and secret access key from config', { verbose: true });
+      s3Options.accessKeyId = accessKeyId;
+      s3Options.secretAccessKey = secretAccessKey;
+    }
+    this._client = this._plugin.readConfig('s3Client') || new AWS.S3(s3Options);
   },
 
   upload: function(options) {

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -124,48 +124,6 @@ describe('s3 plugin', function() {
     });
 
     describe('required config', function() {
-      it('warns about missing accessKeyId', function() {
-        delete context.config.s3.accessKeyId;
-
-        var plugin = subject.createDeployPlugin({
-          name: 's3'
-        });
-        plugin.beforeHook(context);
-        assert.throws(function(error){
-          plugin.configure(context);
-        });
-        var messages = mockUi.messages.reduce(function(previous, current) {
-          if (/- Missing required config: `accessKeyId`/.test(current)) {
-            previous.push(current);
-          }
-
-          return previous;
-        }, []);
-
-        assert.equal(messages.length, 1);
-      });
-
-      it('warns about missing secretAccessKey', function() {
-        delete context.config.s3.secretAccessKey;
-
-        var plugin = subject.createDeployPlugin({
-          name: 's3'
-        });
-        plugin.beforeHook(context);
-        assert.throws(function(error){
-          plugin.configure(context);
-        });
-        var messages = mockUi.messages.reduce(function(previous, current) {
-          if (/- Missing required config: `secretAccessKey`/.test(current)) {
-            previous.push(current);
-          }
-
-          return previous;
-        }, []);
-
-        assert.equal(messages.length, 1);
-      });
-
       it('warns about missing bucket', function() {
         delete context.config.s3.bucket;
 


### PR DESCRIPTION
Not specifying the access key id and secret access key to allow aws-sdk to load from the EC2 instance profile.
Fixes #29 
