### PR TITLE
Configure Cache-Control and Expires headers on the uploaded files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,18 @@ The client specified MUST implement functions called `getObject` and `putObject`
 
 *Default:* the default S3 library is `aws-sdk`
 
+### cacheControl
+
+Sets the `Cache-Control` header on the uploaded files.
+
+*Default:* `max-age=63072000, public`
+
+### expires
+
+Sets the `Expires` header on the uploaded files.
+
+*Default:* `Mon Dec 31 2029 21:00:00 GMT-0300 (CLST)`
+
 ## Prerequisites
 
 The following properties are expected to be present on the deployment `context` object:

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var minimatch = require('minimatch');
 var DeployPluginBase = require('ember-cli-deploy-plugin');
 var S3             = require('./lib/s3');
 
+var EXPIRE_IN_2030               = new Date('2030');
+var TWO_YEAR_CACHE_PERIOD_IN_SEC = 60 * 60 * 24 * 365 * 2;
+
 module.exports = {
   name: 'ember-cli-deploy-s3',
 
@@ -16,6 +19,8 @@ module.exports = {
         filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}',
         prefix: '',
         acl: 'public-read',
+        cacheControl: 'max-age='+TWO_YEAR_CACHE_PERIOD_IN_SEC+', public',
+        expires: EXPIRE_IN_2030,
         distDir: function(context) {
           return context.distDir;
         },
@@ -48,6 +53,8 @@ module.exports = {
         var acl           = this.readConfig('acl');
         var prefix        = this.readConfig('prefix');
         var manifestPath  = this.readConfig('manifestPath');
+        var cacheControl  = this.readConfig('cacheControl');
+        var expires       = this.readConfig('expires');
 
         var filesToUpload = distFiles.filter(minimatch.filter(filePattern, { matchBase: true }));
 
@@ -62,7 +69,9 @@ module.exports = {
           prefix: prefix,
           bucket: bucket,
           acl: acl,
-          manifestPath: manifestPath
+          manifestPath: manifestPath,
+          cacheControl: cacheControl,
+          expires: expires
         };
 
         this.log('preparing to upload to S3 bucket `' + bucket + '`', { verbose: true });

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -7,8 +7,6 @@ var mime       = require('mime');
 var Promise    = require('ember-cli/lib/ext/promise');
 
 var _          = require('lodash');
-var EXPIRE_IN_2030               = new Date('2030');
-var TWO_YEAR_CACHE_PERIOD_IN_SEC = 60 * 60 * 24 * 365 * 2;
 
 module.exports = CoreObject.extend({
   init: function(options) {
@@ -74,8 +72,8 @@ module.exports = CoreObject.extend({
     var prefix           = options.prefix;
     var acl              = options.acl;
     var gzippedFilePaths = options.gzippedFilePaths || [];
-    var cacheControl     = 'max-age='+TWO_YEAR_CACHE_PERIOD_IN_SEC+', public';
-    var expires          = EXPIRE_IN_2030;
+    var cacheControl     = options.cacheControl;
+    var expires          = options.expires;
 
     var manifestPath = options.manifestPath;
     var pathsToUpload = filePaths;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-deploy-plugin": "^0.2.2",
-    "lodash": "^4.11.1",
+    "lodash": "^3.9.3",
     "mime": "^1.3.4",
     "minimatch": "^2.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-deploy-plugin": "^0.2.2",
-    "lodash": "^3.9.3",
+    "lodash": "^4.11.1",
     "mime": "^1.3.4",
     "minimatch": "^2.0.4"
   },

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -120,7 +120,7 @@ describe('s3 plugin', function() {
         return previous;
       }, []);
 
-      assert.equal(messages.length, 2);
+      assert.equal(messages.length, 4);
     });
 
     describe('required config', function() {
@@ -170,9 +170,13 @@ describe('s3 plugin', function() {
     it('adds default config to the config object', function() {
       delete context.config.s3.filePattern;
       delete context.config.s3.prefix;
+      delete context.config.s3.cacheControl;
+      delete context.config.s3.expires;
 
       assert.isUndefined(context.config.s3.filePattern);
       assert.isUndefined(context.config.s3.prefix);
+      assert.isUndefined(context.config.s3.cacheControl);
+      assert.isUndefined(context.config.s3.expires);
 
       var plugin = subject.createDeployPlugin({
         name: 's3'
@@ -180,8 +184,10 @@ describe('s3 plugin', function() {
       plugin.beforeHook(context);
       plugin.configure(context);
 
-      assert.isDefined(context.config.s3.filePattern);
-      assert.isDefined(context.config.s3.prefix);
+      assert.equal(context.config.s3.filePattern, '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}');
+      assert.equal(context.config.s3.prefix, '');
+      assert.equal(context.config.s3.cacheControl, 'max-age=63072000, public');
+      assert.equal(context.config.s3.expires, 'Mon Dec 31 2029 21:00:00 GMT-0300 (CLST)');
     });
   });
 

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -187,7 +187,7 @@ describe('s3 plugin', function() {
       assert.equal(context.config.s3.filePattern, '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}');
       assert.equal(context.config.s3.prefix, '');
       assert.equal(context.config.s3.cacheControl, 'max-age=63072000, public');
-      assert.equal(context.config.s3.expires, 'Mon Dec 31 2029 21:00:00 GMT-0300 (CLST)');
+      assert.equal(new Date(context.config.s3.expires).getTime(), new Date('Tue, 01 Jan 2030 00:00:00 GMT').getTime());;
     });
   });
 

--- a/tests/unit/lib/s3-nodetest.js
+++ b/tests/unit/lib/s3-nodetest.js
@@ -97,7 +97,9 @@ describe('s3', function() {
           cwd: process.cwd() + '/tests/fixtures/dist',
           prefix: 'js-app',
           acl: 'public-read',
-          bucket: 'some-bucket'
+          bucket: 'some-bucket',
+          cacheControl: 'max-age=1234, public',
+          expires: '2010'
         };
 
         var promises = subject.upload(options);
@@ -109,9 +111,9 @@ describe('s3', function() {
             assert.equal(s3Params.Body.toString(), 'body: {}\n');
             assert.equal(s3Params.ContentType, 'text/css; charset=utf-8');
             assert.equal(s3Params.Key, 'js-app/app.css');
-            assert.equal(s3Params.CacheControl, 'max-age=63072000, public');
+            assert.equal(s3Params.CacheControl, 'max-age=1234, public');
+            assert.equal(s3Params.Expires, '2010');
             assert.isUndefined(s3Params.ContentEncoding);
-            assert.deepEqual(s3Params.Expires, new Date('2030'));
           });
       });
 
@@ -128,7 +130,9 @@ describe('s3', function() {
           cwd: process.cwd() + '/tests/fixtures/dist',
           prefix: 'js-app',
           acl: 'public-read',
-          bucket: 'some-bucket'
+          bucket: 'some-bucket',
+          cacheControl: 'max-age=1234, public',
+          expires: '2010'
         };
 
         var promises = subject.upload(options);
@@ -137,9 +141,9 @@ describe('s3', function() {
           .then(function() {
             assert.equal(s3Params.ContentType, 'text/css; charset=utf-8');
             assert.equal(s3Params.Key, 'js-app/app.css.gz');
-            assert.equal(s3Params.CacheControl, 'max-age=63072000, public');
             assert.equal(s3Params.ContentEncoding, 'gzip');
-            assert.deepEqual(s3Params.Expires, new Date('2030'));
+            assert.equal(s3Params.CacheControl, 'max-age=1234, public');
+            assert.equal(s3Params.Expires, '2010');
           });
       });
     });


### PR DESCRIPTION
This PR adds the ability to configure the `Cache-Control` and `Expires` headers through the `cacheControl` and `expires` configuration options.

Solves https://github.com/ember-cli-deploy/ember-cli-deploy-s3/issues/52
