### PR TITLE
Includes session token if provided to client initialization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For detailed information on how configuration of plugins works, please refer to 
 
 ### accessKeyId
 
-The AWS access key for the user that has the ability to upload to the `bucket`. If this is left undefined, 
+The AWS access key for the user that has the ability to upload to the `bucket`. If this is left undefined,
 the normal [AWS SDK credential resolution][5] will take place.
 
 *Default:* `undefined`
@@ -73,6 +73,13 @@ the normal [AWS SDK credential resolution][5] will take place.
 ### secretAccessKey
 
 The AWS secret for the user that has the ability to upload to the `bucket`. This must be defined when `accessKeyId` is defined.
+
+*Default:* `undefined`
+
+### sessionToken
+
+The AWS session token for the user that has the ability to upload to the `bucket`. This may be required if you are using the [AWS Security Token Service][6].
+This requires both `accessKeyId` and `secretAccessKey` to be defined.
 
 *Default:* `undefined`
 
@@ -216,7 +223,7 @@ To properly serve certain assets (i.e. webfonts) a basic CORS configuration is n
 
 Replace **http://www.your-site.com** with your domain.
 
-Some more info: [Amazon CORS guide][6], [Stackoverflow][7]
+Some more info: [Amazon CORS guide][7], [Stackoverflow][8]
 
 
 ## Running Tests
@@ -228,5 +235,6 @@ Some more info: [Amazon CORS guide][6], [Stackoverflow][7]
 [3]: https://github.com/lukemelia/ember-cli-deploy-gzip "ember-cli-deploy-gzip"
 [4]: https://github.com/lukemelia/ember-cli-deploy-manifest "ember-cli-deploy-manifest"
 [5]: https://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials "Setting AWS Credentials"
-[6]: http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html "Amazon CORS guide"
-[7]: http://stackoverflow.com/questions/12229844/amazon-s3-cors-cross-origin-resource-sharing-and-firefox-cross-domain-font-loa?answertab=votes#tab-top "Stackoverflow"
+[6]: http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html "AWS Security Token Service guide"
+[7]: http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html "Amazon CORS guide"
+[8]: http://stackoverflow.com/questions/12229844/amazon-s3-cors-cross-origin-resource-sharing-and-firefox-cross-domain-font-loa?answertab=votes#tab-top "Stackoverflow"

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -15,14 +15,22 @@ module.exports = CoreObject.extend({
     var s3Options = {
       region: this._plugin.readConfig('region')
     };
+
     const accessKeyId = this._plugin.readConfig('accessKeyId');
     const secretAccessKey = this._plugin.readConfig('secretAccessKey');
+    const sessionToken = this._plugin.readConfig('sessionToken');
 
     if (accessKeyId && secretAccessKey) {
       this._plugin.log('Using AWS access key id and secret access key from config', { verbose: true });
       s3Options.accessKeyId = accessKeyId;
       s3Options.secretAccessKey = secretAccessKey;
     }
+
+    if (sessionToken) {
+      this._plugin.log('Using AWS session token from config', { verbose: true });
+      s3Options.sessionToken = sessionToken;
+    }
+
     this._client = this._plugin.readConfig('s3Client') || new AWS.S3(s3Options);
   },
 

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -35,6 +35,7 @@ describe('s3 plugin', function() {
         s3: {
           accessKeyId: 'aaaa',
           secretAccessKey: 'bbbb',
+          sessionToken: 'eeee',
           bucket: 'cccc',
           region: 'dddd',
           filePattern: '*.{css,js}',


### PR DESCRIPTION
If you're using Temporary Credentials with AWS STS, you must include a
session token.

Reference:
http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/prog-services-sts.html
