### PR TITLE
Update minimum S3 permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ Ensure you have the minimum required permissions configured for the user (access
             ],
             "Resource": [
                 "arn:aws:s3:::<your-s3-bucket-name>/*"
-            ]
+            ],
+            "Principal": { "AWS": "arn:aws:iam::AWS-account-ID:root" }
         }
     ]
 }


### PR DESCRIPTION
When I used the old minimum S3 permissions, I got an error: `Statement is missing required element - Statement "Stmt1EmberCLIS3DeployPolicy" is missing "Principal" element.

This PR adds in the Principal element, based on [this documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Principal)
