### PR TITLE
fix #59

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-cli-deploy-plugin"
   ],
   "dependencies": {
-    "aws-sdk": "^2.1.25",
+    "aws-sdk": "~2.3.19",
     "chalk": "^1.0.0",
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.0.0",


### PR DESCRIPTION
## What Changed & Why

new version of aws-sdk is giving problems
## Related issues

https://github.com/ember-cli-deploy/ember-cli-deploy-s3/issues/59
## Future

more investigation is needed to understand what we should do to move to aws-sdk `2.4.X`
