### PR TITLE
Add network proxy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ Sets the default mime type, used when it cannot be determined from the file exte
 
 *Default:* `application/octet-stream`
 
+### proxy
+
+The network proxy url used when sending requests to S3.
+
+*Default:* `undefined`
+
 ## Prerequisites
 
 The following properties are expected to be present on the deployment `context` object:

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -16,6 +16,14 @@ module.exports = CoreObject.extend({
       region: this._plugin.readConfig('region')
     };
 
+    const proxy = this._plugin.readConfig('proxy');
+    if (proxy) {
+      this._proxyAgent = this._plugin.readConfig('proxyAgent') || require('proxy-agent');
+      s3Options.httpOptions = {
+        agent: this._proxyAgent(proxy)
+      };
+    }
+
     const accessKeyId = this._plugin.readConfig('accessKeyId');
     const secretAccessKey = this._plugin.readConfig('secretAccessKey');
     const sessionToken = this._plugin.readConfig('sessionToken');

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "ember-cli-deploy-plugin": "^0.2.2",
     "lodash": "^3.9.3",
     "mime": "^1.3.4",
-    "minimatch": "^2.0.4"
+    "minimatch": "^2.0.4",
+    "proxy-agent": "^2.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -41,6 +41,7 @@ describe('s3 plugin', function() {
           filePattern: '*.{css,js}',
           acl: 'authenticated-read',
           prefix: '',
+          proxy: 'http://user:password@internal.proxy.com',
           distDir: function(context) {
             return context.distDir;
           },
@@ -245,6 +246,27 @@ describe('s3 plugin', function() {
           assert.equal(mockUi.messages.length, 3);
           assert.match(mockUi.messages[1], /- Error: something bad went wrong/);
         });
+    });
+
+    it('calls proxy agent if a proxy is specified', function(done) {
+      var plugin = subject.createDeployPlugin({
+        name: 's3'
+      });
+
+      var assertionCount = 0
+      context.proxyAgent = function(proxy) {
+        assertionCount++;
+      };
+
+      plugin.beforeHook(context);
+      plugin.configure(context);
+
+      return assert.isFulfilled(plugin.upload(context)).then(function(){
+        assert.equal(assertionCount, 1);
+        done();
+      }).catch(function(reason){
+        done(reason.actual.stack);
+      });
     });
 
     it('sets the appropriate header if the file is inclued in gzippedFiles list', function(done) {


### PR DESCRIPTION
We deploy behind a proxy so we needed the proxy option to be available. Just grabbed from here: http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Configuring_a_Proxy
