### PR TITLE
Add otf file type to default filePattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ A directory within the `bucket` that the files should be uploaded in to.
 
 Files that match this pattern will be uploaded to S3. The file pattern must be relative to `distDir`.
 
-*Default:* '\*\*/\*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}'
+*Default:* '\*\*/\*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf}'
 
 ### distDir
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
       defaultConfig: {
-        filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}',
+        filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf}',
         prefix: '',
         acl: 'public-read',
         cacheControl: 'max-age='+TWO_YEAR_CACHE_PERIOD_IN_SEC+', public',

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -185,7 +185,7 @@ describe('s3 plugin', function() {
       plugin.beforeHook(context);
       plugin.configure(context);
 
-      assert.equal(context.config.s3.filePattern, '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}');
+      assert.equal(context.config.s3.filePattern, '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf}');
       assert.equal(context.config.s3.prefix, '');
       assert.equal(context.config.s3.cacheControl, 'max-age=63072000, public');
       assert.equal(new Date(context.config.s3.expires).getTime(), new Date('Tue, 01 Jan 2030 00:00:00 GMT').getTime());;


### PR DESCRIPTION
## What Changed & Why

Appending `.otf` to the filePattern list (support uploading OpenType font files)
## Related issues

Link to related issues in this or other repositories (if any)
## PR Checklist
- [x] Add tests - edit existing test
- [x] Add documentation - update docs
- [x] Prefix documentation-only commits with [DOC] - not applicable
## People

Mention people who would be interested in the changeset (if any)
@achambers re: slack convo

TrueType is already included, so why not OpenType as well?
