### PR TITLE
Allow setting of default mime type for files with no extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ Sets the `Expires` header on the uploaded files.
 
 *Default:* `Mon Dec 31 2029 21:00:00 GMT-0300 (CLST)`
 
+### defaultMimeType
+
+Sets the default mime type, used when it cannot be determined from the file extension.
+
+*Default:* `application/octet-stream`
+
 ## Prerequisites
 
 The following properties are expected to be present on the deployment `context` object:

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -92,6 +92,8 @@ module.exports = CoreObject.extend({
     var cacheControl     = options.cacheControl;
     var expires          = options.expires;
 
+    mime.default_type = options.defaultMimeType || mime.lookup('bin');
+
     return filePaths.map(function(filePath) {
       var basePath    = path.join(cwd, filePath);
       var data        = fs.readFileSync(basePath);

--- a/tests/fixtures/dist/index
+++ b/tests/fixtures/dist/index
@@ -1,0 +1,1 @@
+<p>Some HTML</p>

--- a/tests/unit/lib/s3-nodetest.js
+++ b/tests/unit/lib/s3-nodetest.js
@@ -146,6 +146,47 @@ describe('s3', function() {
             assert.equal(s3Params.Expires, '2010');
           });
       });
+
+      it('sets the content type using defaultMimeType', function() {
+        var s3Params;
+        s3Client.putObject = function(params, cb) {
+          s3Params = params;
+          cb();
+        };
+
+        var options = {
+          filePaths: ['index'],
+          cwd: process.cwd() + '/tests/fixtures/dist',
+          defaultMimeType: 'text/html'
+        };
+
+        var promises = subject.upload(options);
+
+        return assert.isFulfilled(promises)
+          .then(function() {
+            assert.equal(s3Params.ContentType, 'text/html; charset=utf-8');
+          });
+        });
+
+      it('sets the content type to the default', function() {
+        var s3Params;
+        s3Client.putObject = function(params, cb) {
+          s3Params = params;
+          cb();
+        };
+
+        var options = {
+          filePaths: ['index'],
+          cwd: process.cwd() + '/tests/fixtures/dist'
+        };
+
+        var promises = subject.upload(options);
+
+        return assert.isFulfilled(promises)
+          .then(function() {
+            assert.equal(s3Params.ContentType, 'application/octet-stream');
+          });
+        });
     });
 
     describe('with a manifestPath specified', function () {


### PR DESCRIPTION
Adds ability to set a default mime type other than 'application/octet-stream'. In my case I want to deploy a static site generated by [ember-cli-static-site](https://github.com/robwebdev/ember-cli-static-site) that contains html files without an extension but with the content-type of `text/html`.  
