### PR TITLE
[Bugfix] Remove the Principal Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ Ensure you have the minimum required permissions configured for the user (access
             ],
             "Resource": [
                 "arn:aws:s3:::<your-s3-bucket-name>/*"
-            ],
-            "Principal": { "AWS": "arn:aws:iam::AWS-account-ID:root" }
+            ]
         }
     ]
 }


### PR DESCRIPTION
## What Changed & Why

Removes the Principle property from the S3 permissions statement. This was removed because it caused the following error on S3 when it's provided:

`An error occurred: Policy document should not specify a principal.`
## PR Checklist
- [ ] Update Documentation
