### PR TITLE
filesUploaded should return all files when using manifest

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -41,8 +41,10 @@ module.exports = CoreObject.extend({
 
       const manifestPath = options.manifestPath;
       if (manifestPath) {
-        return allFilesUploaded.then(function() {
-          return Promise.all(this._putObjects([manifestPath], options));
+        return allFilesUploaded.then(function(filesUploaded) {
+          return Promise.all(this._putObjects([manifestPath], options)).then(function(manifestUploaded) {
+            return filesUploaded.concat(manifestUploaded);
+          });
         }.bind(this));
       } else {
         return allFilesUploaded;


### PR DESCRIPTION
After https://github.com/ember-cli-deploy/ember-cli-deploy-s3/pull/55  `context.filesUploaded` will only return `['manifest.txt']` if using a manifest

This returns the originally uploaded files in addition to the manifest
