### PR TITLE
[DOC] Add tip for slashes in the prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The ACL to apply to the objects.
 
 ### prefix
 
-A directory within the `bucket` that the files should be uploaded in to.
+A directory within the `bucket` that the files should be uploaded in to. It should not have a leading or trailing slash.
 
 *Default:* `''`
 


### PR DESCRIPTION
## What Changed & Why

I added a note on slashes in the prefix because that was not clear for me in the docs when I started. When I looked at the code I saw a `join` being used without a check for the slashes. So to make it work you should not add a slash at the begin nor the end of the `prefix`.
## Related issues

None.
## PR Checklist
- [ ] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]
## People

None.
