### PR TITLE
added config to include hidden folders in the S3 upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ The list of built project files. This option should be relative to `distDir` and
 
 *Default:* `context.distFiles`
 
+### dotFolders
+
+This is a boolean that can be set to `true` to include hidden folders
+(that are prefixed with a `.`) as folders that can be uploaded to S3.
+
+*Default:* `false`
+
 ### gzippedFiles
 
 The list of files that have been gziped. This option should be relative to `distDir`. By default, this option will use the `gzippedFiles` property of the deployment context, provided by [ember-cli-deploy-gzip][3].

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = {
         acl: 'public-read',
         cacheControl: 'max-age='+TWO_YEAR_CACHE_PERIOD_IN_SEC+', public',
         expires: EXPIRE_IN_2030,
+        dotFolders: false,
         distDir: function(context) {
           return context.distDir;
         },
@@ -55,8 +56,9 @@ module.exports = {
         var manifestPath  = this.readConfig('manifestPath');
         var cacheControl  = this.readConfig('cacheControl');
         var expires       = this.readConfig('expires');
+        var dotFolders    = this.readConfig('dotFolders');
 
-        var filesToUpload = distFiles.filter(minimatch.filter(filePattern, { matchBase: true }));
+        var filesToUpload = distFiles.filter(minimatch.filter(filePattern, { matchBase: true, dot: dotFolders }));
 
         var s3 = this.readConfig('uploadClient') || new S3({
           plugin: this

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -122,7 +122,7 @@ describe('s3 plugin', function() {
         return previous;
       }, []);
 
-      assert.equal(messages.length, 4);
+      assert.equal(messages.length, 5);
     });
 
     describe('required config', function() {


### PR DESCRIPTION
## What Changed & Why

I added a config property so that we can upload files in hidden folders. We're adding apple pay to our application and it requires a folder called `.well-known/` to exist. It looks like you need to tell the `minimatch` npm module that you want to include hidden folders as part of the matching criteria, otherwise it will ignore files in folders that are prefixed by `.`
