### PR TITLE
Loosen aws-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-cli-deploy-plugin"
   ],
   "dependencies": {
-    "aws-sdk": "~2.3.19",
+    "aws-sdk": "^2.6.12",
     "chalk": "^1.0.0",
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.0.0",


### PR DESCRIPTION
## What Changed & Why
The current aws-sdk version string `~2.3.19` forces an old version of aws-sdk due to brokenness in 2.4.0.  The signing issues mentioned #59 in seem to have been fixed in 2.4.1.

Personally I'm blocked on the ECS Credential stuff added in 2.4.7.  2.6.12 is current newest release.

## Related issues
https://github.com/ember-cli-deploy/ember-cli-deploy-s3/issues/59
https://github.com/aws/aws-sdk-js/compare/v2.4.0...v2.4.1