### PR TITLE
Update minimatch to ^3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ember-cli-deploy-plugin": "^0.2.2",
     "lodash": "^3.9.3",
     "mime": "^1.3.4",
-    "minimatch": "^2.0.4",
+    "minimatch": "^3.0.3",
     "proxy-agent": "^2.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
## What Changed & Why
minimatch dependency updated to avoid security risk.

Was getting a warning to update to this version to avoid a possibility of a DDOS attack.

`warning ember-cli-deploy-manifest > minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue`

