### PR TITLE
[DOC] Fix broken link to 'Plugin Documentation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Some more info: [Amazon CORS guide][7], [Stackoverflow][8]
 
 - `npm test`
 
-[1]: http://ember-cli.github.io/ember-cli-deploy/plugins "Plugin Documentation"
+[1]: http://ember-cli-deploy.com/plugins/ "Plugin Documentation"
 [2]: https://github.com/ember-cli-deploy/ember-cli-deploy-build "ember-cli-deploy-build"
 [3]: https://github.com/lukemelia/ember-cli-deploy-gzip "ember-cli-deploy-gzip"
 [4]: https://github.com/lukemelia/ember-cli-deploy-manifest "ember-cli-deploy-manifest"


### PR DESCRIPTION
## What Changed & Why
What: Changed link to plugin documentation to point to newer ember-cli-deploy site.
Why: I was getting 404 for the old link.

I think it was going to old page on ember-cli.com site which has since been moved to its own dedicated site: ember-cli-deploy.com

## Related issues
None

## PR Checklist
- [ ] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]


## People
Not sure who

