### PR TITLE
Add confi option for signatureVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ Useful when deploying applications to [fake-s3](https://github.com/jubos/fake-s3
 
 *Default:* `0`
 
+
+### signatureVersion
+
+`signatureVersion` allows for setting the Signature Version. In the Asia Pacific (Mumbai), Asia Pacific (Seoul), EU (Frankfurt) and China (Beijing) regions, Amazon S3 supports only Signature Version 4. In all other regions, Amazon S3 supports both Signature Version 4 and Signature Version 2.
+
+*Example value*: `'v4'`
+
+*Default*: `undefined`
+
 ## Prerequisites
 
 The following properties are expected to be present on the deployment `context` object:

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -28,11 +28,17 @@ module.exports = CoreObject.extend({
     const secretAccessKey = this._plugin.readConfig('secretAccessKey');
     const sessionToken = this._plugin.readConfig('sessionToken');
     const profile = this._plugin.readConfig('profile');
+    const signatureVersion = this._plugin.readConfig('signatureVersion');
 
     if (accessKeyId && secretAccessKey) {
       this._plugin.log('Using AWS access key id and secret access key from config', { verbose: true });
       s3Options.accessKeyId = accessKeyId;
       s3Options.secretAccessKey = secretAccessKey;
+    }
+
+    if (signatureVersion) {
+      this._plugin.log('Using signature version from config', { verbose: true });
+      s3Options.signatureVersion = signatureVersion;
     }
 
     if (sessionToken) {


### PR DESCRIPTION
## What Changed & Why

Made it possible to set the [signature version](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version) for AWS S3.

More information about this option is available [in this AWS S3 documentation page](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version).

## Related issues

https://github.com/ember-cli-deploy/ember-cli-deploy-s3/issues/82

## PR Checklist
- [ ] Add tests
- [x] Add documentation
- [ ] Prefix documentation-only commits with [DOC]