### PR TITLE
Instructions to set up public access to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,11 @@ The following properties are expected to be present on the deployment `context` 
 
 ### Deployment user and S3 permissions
 
-The environment in which the `ember deploy` command is run (outside of development) needs to have an AWS account with a policy that allows writing to the S3 bucket.
-The best way to do this is to create an IAM user to be the "deployer", and place its security credentials (Access Key ID and Access Secret) in the environment on the server or CI environment where deployment takes place.
+The environment in which the `ember deploy` command is run needs to have an AWS account with a policy that allows writing to the S3 bucket.
+
+It's common for a development machine to be set up with the developer's personal AWS credentials, which likely have the ability to administer the entire AWS account. This will allow deployment to work from the development machine, but it is not a good idea to copy your personal credentials to production.
+
+The best way to set up non-development deployment is to create an IAM user to be the "deployer", and [place its security credentials][9] (Access Key ID and Access Secret) in the environment on the machine or CI environment where deployment takes place. (The easiest way to do this in CI is to set environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.)
 
 A bare minimum policy should have the following permissions:
 
@@ -315,3 +318,4 @@ Some more info: [Amazon CORS guide][7], [Stackoverflow][8]
 [6]: http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html "AWS Security Token Service guide"
 [7]: http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html "Amazon CORS guide"
 [8]: http://stackoverflow.com/questions/12229844/amazon-s3-cors-cross-origin-resource-sharing-and-firefox-cross-domain-font-loa?answertab=votes#tab-top "Stackoverflow"
+[9]: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files "AWS Configuration"

--- a/README.md
+++ b/README.md
@@ -229,11 +229,14 @@ The following properties are expected to be present on the deployment `context` 
 
 ## Configuring Amazon S3
 
-### Minimum S3 Permissions
+### Deployment user and S3 permissions
 
-Ensure you have the minimum required permissions configured for the user (accessKeyId). A bare minimum policy should have the following permissions:
+The server, user account, or CI environment that deploys needs to have a policy that allows writing to the S3 bucket.
+The best way to do this is to create an IAM user to be the "deployer", and place its security credentials (Access Key ID and Access Secret) in the environment where the `ember deploy` command will be run.
 
-```
+A bare minimum policy should have the following permissions:
+
+```js
 {
     "Statement": [
         {
@@ -245,20 +248,45 @@ Ensure you have the minimum required permissions configured for the user (access
                 "s3:PutObjectACL"
             ],
             "Resource": [
-                "arn:aws:s3:::<your-s3-bucket-name>/*"
+                "arn:aws:s3:::your-s3-bucket-name/*"
             ]
         }
     ]
 }
-
 ```
-Replace <your-s3-bucket-name> with the name of the actual bucket you are deploying to. Also, remember that "PutObject" permission will effectively overwrite any existing files with the same name unless you use a fingerprinting or a manifest plugin.
+
+Replace `your-s3-bucket-name` with the name of the actual bucket you are deploying to.
+
+Also, remember that "PutObject" permission will effectively overwrite any existing files with the same name unless you use a fingerprinting or a manifest plugin.
+
+### S3 policy for public access
+
+If you want the contents of the S3 bucket to be accessible to the world, the following policy can be placed directly in the S3 bucket policy:
+
+```js
+{
+    "Statement": [
+        {
+            "Sid": "Stmt1EmberCLIS3AccessPolicy",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+            ],
+            "Resource": [
+                "arn:aws:s3:::your-s3-bucket-name/*"
+            ]
+        }
+    ]
+}
+```
+
+Replace `your-s3-bucket-name` with the name of the actual bucket you are deploying to.
 
 ### Sample CORS configuration
 
 To properly serve certain assets (i.e. webfonts) a basic CORS configuration is needed
 
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <CORSRule>

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ The following properties are expected to be present on the deployment `context` 
 
 ### Deployment user and S3 permissions
 
-The server, user account, or CI environment that deploys needs to have a policy that allows writing to the S3 bucket.
-The best way to do this is to create an IAM user to be the "deployer", and place its security credentials (Access Key ID and Access Secret) in the environment where the `ember deploy` command will be run.
+The environment in which the `ember deploy` command is run (outside of development) needs to have an AWS account with a policy that allows writing to the S3 bucket.
+The best way to do this is to create an IAM user to be the "deployer", and place its security credentials (Access Key ID and Access Secret) in the environment on the server or CI environment where deployment takes place.
 
 A bare minimum policy should have the following permissions:
 


### PR DESCRIPTION
- More specific instructions on how to set up S3 access to the deployment process.
- Example policy to allow outside access to the S3 bucket.
- Improved formatting and fixed a syntax issue.

The existing documentation included some details on the policy object to provide access to the deployment script, but it seemed a little ambiguous. I added some wording to make it obvious that the deployment script needs to have its own user with `Put` permission to the bucket, and that the policy should be applied to that user account.

I added an example policy to help someone provide access to the S3 bucket so that they can serve the assets to users on the web.

The existing policy included < and > around the example string that should be replaced, but this didn't really make it stand out, and the text explaining that it needs to be replaced wasn't being formatted correctly (it looked like an HTML tag, so it was either being suppressed by Github's markdown-to-HTML processor).