### PR TITLE
Replace `ember-cli/ext/promise` with `rsvp`

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -13,11 +13,11 @@
 
 var EOL       = require('os').EOL;
 var multiline = require('multiline');
-var Promise   = require('ember-cli/lib/ext/promise');
+var RSVP      = require('rsvp');
 var GitHubApi = require('github');
 
 var github         = new GitHubApi({version: '3.0.0'});
-var compareCommits = Promise.denodeify(github.repos.compareCommits);
+var compareCommits = RSVP.denodeify(github.repos.compareCommits);
 var currentVersion = 'v' + require('../package').version;
 
 var user = 'ember-cli-deploy';

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 'use strict';
 
-var Promise   = require('ember-cli/lib/ext/promise');
+var RSVP      = require('rsvp');
 var minimatch = require('minimatch');
 var DeployPluginBase = require('ember-cli-deploy-plugin');
 var S3             = require('./lib/s3');
@@ -99,7 +99,7 @@ module.exports = {
         if (error) {
           this.log(error.stack, { color: 'red' });
         }
-        return Promise.reject(error);
+        return RSVP.reject(error);
       }
     });
     return new DeployPlugin();

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -4,7 +4,7 @@ var fs         = require('fs');
 var path       = require('path');
 var mime       = require('mime');
 
-var Promise    = require('ember-cli/lib/ext/promise');
+var RSVP       = require('rsvp');
 
 var _          = require('lodash');
 
@@ -97,10 +97,10 @@ module.exports = CoreObject.extend({
         return _.difference(filePaths, manifestEntries);
       }).catch(function(/* reason */){
         plugin.log("Manifest not found. Disabling differential deploy.", { color: 'yellow', verbose: true });
-        return Promise.resolve(filePaths);
+        return RSVP.resolve(filePaths);
       });
     } else {
-      return Promise.resolve(filePaths);
+      return RSVP.resolve(filePaths);
     }
   },
 
@@ -155,7 +155,7 @@ module.exports = CoreObject.extend({
       params.ContentEncoding = 'gzip';
     }
 
-    return new Promise(function(resolve, reject) {
+    return new RSVP.Promise(function(resolve, reject) {
       this._client.putObject(params, function(error) {
         if (error) {
           reject(error);
@@ -174,7 +174,7 @@ module.exports = CoreObject.extend({
     this._currentEnd += currentBatch.length;
 
     //Execute our current batch of promises
-    return Promise.all(currentBatch.map(function (filePath) {
+    return RSVP.all(currentBatch.map(function (filePath) {
       return this._putObject(filePath, options, filePaths);
     }.bind(this)))
     //Then check if we need to execute another batch
@@ -193,7 +193,7 @@ module.exports = CoreObject.extend({
       return this._putObjectsBatch(filePaths, options);
     }
 
-    return Promise.all(filePaths.map(function (filePath) {
+    return RSVP.all(filePaths.map(function (filePath) {
       return this._putObject(filePath, options, filePaths);
     }.bind(this)));
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lodash": "^4.17.4",
     "mime": "^1.3.4",
     "minimatch": "^3.0.3",
-    "proxy-agent": "^2.0.0"
+    "proxy-agent": "^2.0.0",
+    "rsvp": "^3.5.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -5,7 +5,7 @@ var chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised);
 
 var assert = chai.assert;
-var Promise = require('ember-cli/lib/ext/promise');
+var RSVP = require('rsvp');
 
 describe('s3 plugin', function() {
   var subject;
@@ -32,7 +32,7 @@ describe('s3 plugin', function() {
       ui: mockUi,
       uploadClient: {
         upload: function(options) {
-          return Promise.resolve(['app.css', 'app.js']);
+          return RSVP.resolve(['app.css', 'app.js']);
         }
       },
       config: {
@@ -241,7 +241,7 @@ describe('s3 plugin', function() {
 
       context.uploadClient = {
         upload: function(opts) {
-          return Promise.reject(new Error('something bad went wrong'));
+          return RSVP.reject(new Error('something bad went wrong'));
         }
       };
 


### PR DESCRIPTION
This would fix #87. I used [this PR](https://github.com/ember-cli-deploy/ember-cli-deploy-revision-data/pull/55) as a guideline and transformed similarly.

_However_, I did need to add RSVP as a dependency. NPM chose the current version of 3.5.0, but I could easily change it to something else if that’s preferable.

Thanks for this, it lets us have automatic test deployments of `travis-web` PRs, very useful!