### PR TITLE
DOC - formatting updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ For detailed information on what plugin hooks are and how they work, please refe
 For detailed information on how configuration of plugins works, please refer to the [Plugin Documentation][1].
 
 <hr/>
-**WARNING: Don't share a configuration object between [ember-cli-deploy-s3-index](https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index) and this plugin. The way these two plugins read their configuration has sideeffects which will unfortunately break your deploy if you share one configuration object between the two** (we are already working on a fix)
+
+**WARNING:** Don't share a configuration object between [ember-cli-deploy-s3-index](https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index) and this plugin. The way these two plugins read their configuration has sideeffects which will unfortunately break your deploy if you share one configuration object between the two (we are already working on a fix)
+
 <hr/>
 
 ### accessKeyId
@@ -308,7 +310,7 @@ Some more info: [Amazon CORS guide][7], [Stackoverflow][8]
 
 ## Tests
 
-* yarn test
+* `yarn test`
 
 ## Why `ember build` and `ember test` don't work
 


### PR DESCRIPTION
## What Changed & Why

Bolding the entire paragraph wasn't linking properly to `ember-cli-deploy-s3-index`. Also formatting of `yarn test`.

## Related issues

n/a

## PR Checklist
- [ ] Add tests (n/a)
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]

## People

n/a
