### PR TITLE
Fix defaultMimeType option binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ module.exports = {
         var dotFolders            = this.readConfig('dotFolders');
         var serverSideEncryption  = this.readConfig('serverSideEncryption');
         var batchSize             = this.readConfig('batchSize');
+        var defaultMimeType       = this.readConfig('defaultMimeType');
 
         var filesToUpload = distFiles.filter(minimatch.filter(filePattern, { matchBase: true, dot: dotFolders }));
 
@@ -78,7 +79,8 @@ module.exports = {
           manifestPath: manifestPath,
           cacheControl: cacheControl,
           expires: expires,
-          batchSize: batchSize
+          batchSize: batchSize,
+          defaultMimeType: defaultMimeType
         };
 
         if (serverSideEncryption) {

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
         expires: EXPIRE_IN_2030,
         dotFolders: false,
         batchSize: 0,
+        defaultMimeType: 'application/octet-stream',
         distDir: function(context) {
           return context.distDir;
         },

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -128,7 +128,7 @@ describe('s3 plugin', function() {
         return previous;
       }, []);
 
-      assert.equal(messages.length, 6);
+      assert.equal(messages.length, 7);
     });
 
     describe('required config', function() {


### PR DESCRIPTION
## What Changed & Why
defaultMimeType field is ignored in the ember-cli-deploy options, as it isn't passed into the s3 options correctly. This pull request fixes this binding

## Related issues
Here is the issue: https://github.com/ember-cli-deploy/ember-cli-deploy-s3/issues/93

