### PR TITLE
Add JSON to the default filePattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ A directory within the `bucket` that the files should be uploaded in to. It shou
 
 Files that match this pattern will be uploaded to S3. The file pattern must be relative to `distDir`.
 
-*Default:* '\*\*/\*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf}'
+*Default:* '\*\*/\*.{js,css,png,gif,ico,jpg,map,json,xml,txt,svg,swf,eot,ttf,woff,woff2,otf}'
 
 ### distDir
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
       defaultConfig: {
-        filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf}',
+        filePattern: '**/*.{js,css,png,gif,ico,jpg,map,json,xml,txt,svg,swf,eot,ttf,woff,woff2,otf}',
         prefix: '',
         profile: '',
         acl: 'public-read',

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -192,7 +192,7 @@ describe('s3 plugin', function() {
       plugin.beforeHook(context);
       plugin.configure(context);
 
-      assert.equal(context.config.s3.filePattern, '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf}');
+      assert.equal(context.config.s3.filePattern, '**/*.{js,css,png,gif,ico,jpg,map,json,xml,txt,svg,swf,eot,ttf,woff,woff2,otf}');
       assert.equal(context.config.s3.prefix, '');
       assert.equal(context.config.s3.cacheControl, 'max-age=63072000, public');
       assert.equal(new Date(context.config.s3.expires).getTime(), new Date('Tue, 01 Jan 2030 00:00:00 GMT').getTime());


### PR DESCRIPTION
## What Changed & Why
Add `json` to the default filePattern. 

One use case for this is if you have `manifest.json` file in your public folder.
