### PR TITLE
contentType handled properly

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -125,14 +125,14 @@ module.exports = CoreObject.extend({
     var isBrotliCompressed = brotliCompressedFilePaths.indexOf(filePath) !== -1;
 
     if (isGzipped && path.extname(basePath) === '.gz') {
-      var basePathUngzipped = path.basename(basePath, '.gz');
+      var basePathUngzipped = filePath.slice(0, -3);
       if (filePaths && filePaths.indexOf(basePathUngzipped) !== -1) {
         contentType = mime.lookup(basePathUngzipped);
         encoding = mime.charsets.lookup(contentType);
       }
     }
     if (isBrotliCompressed) {
-      var basePathUncompressed = path.basename(basePath, '.br');
+      var basePathUncompressed = filePath.slice(0, -3);
       if (filePaths && filePaths.indexOf(basePathUncompressed) !== -1) {
         contentType = mime.lookup(basePathUncompressed);
         encoding = mime.charsets.lookup(contentType);


### PR DESCRIPTION
## What Changed & Why
when the assets are present inside sub-folder content type for the .gz, .br extension files are not set properly.

## Related issues
Link to related issues in this or other repositories (if any)

## PR Checklist
- [ ] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People
Mention people who would be interested in the changeset (if any)
