### PR TITLE
Add fileIgnorePattern option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Files that match this pattern will be uploaded to S3. The file pattern must be r
 
 *Default:* '\*\*/\*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf,wasm}'
 
+### fileIgnorePattern
+
+Files matching this pattern will _not_ be uploaded even if they match filePattern.
+
+*Default:* `null`
+
 ### distDir
 
 The root directory where the files matching `filePattern` will be searched for. By default, this option will use the `distDir` property of the deployment context, provided by [ember-cli-deploy-build][2].

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
       name: options.name,
       defaultConfig: {
         filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf,wasm}',
+        fileIgnorePattern: null,
         prefix: '',
         profile: '',
         acl: 'public-read',
@@ -53,6 +54,7 @@ module.exports = {
         var self                  = this;
 
         var filePattern           = this.readConfig('filePattern');
+        var fileIgnorePattern     = this.readConfig('fileIgnorePattern');
         var distDir               = this.readConfig('distDir');
         var distFiles             = this.readConfig('distFiles');
         var gzippedFiles          = this.readConfig('gzippedFiles');
@@ -69,6 +71,17 @@ module.exports = {
         var defaultMimeType       = this.readConfig('defaultMimeType');
 
         var filesToUpload = distFiles.filter(minimatch.filter(filePattern, { matchBase: true, dot: dotFolders }));
+        if (fileIgnorePattern) {
+          filesToUpload = filesToUpload.filter(function(path) {
+            return !minimatch(path, fileIgnorePattern, { matchBase: true });
+          });
+          gzippedFiles = gzippedFiles.filter(function(path) {
+            return !minimatch(path, fileIgnorePattern, { matchBase: true });
+          });
+          brotliCompressedFiles = brotliCompressedFiles.filter(function(path) {
+            return !minimatch(path, fileIgnorePattern, { matchBase: true });
+          });
+        }
 
         var s3 = this.readConfig('uploadClient') || new S3({
           plugin: this

--- a/tests/lib/s3-test.js
+++ b/tests/lib/s3-test.js
@@ -1,4 +1,5 @@
 /*eslint-env node*/
+var os = require('os');
 var chai  = require('chai');
 var chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised);
@@ -112,7 +113,7 @@ describe('s3', function() {
           .then(function() {
             assert.equal(s3Params.Bucket, 'some-bucket');
             assert.equal(s3Params.ACL, 'public-read');
-            assert.equal(s3Params.Body.toString(), 'body: {}\n');
+            assert.equal(s3Params.Body.toString(), 'body: {}' + os.EOL);
             assert.equal(s3Params.ContentType, 'text/css; charset=utf-8');
             assert.equal(s3Params.Key, 'js-app/app.css');
             assert.equal(s3Params.CacheControl, 'max-age=1234, public');


### PR DESCRIPTION
## What Changed & Why
This PR adds the option to specify `fileIgnorePattern`, to ignore certain files (like `sw.js`).

Usage:

```js
s3: {
  // other configuration
  fileIgnorePattern: 'sw.js'
}
```

## Related issues

This is an alternative solution for #97.

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]
