### PR TITLE
Add .json to default `filePattern`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ A directory within the `bucket` that the files should be uploaded in to. It shou
 
 Files that match this pattern will be uploaded to S3. The file pattern must be relative to `distDir`. For an advanced usage, you may want to check out [isaacs/minimatch](https://github.com/isaacs/minimatch#usage)'s documentation.
 
-*Default:* `'**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf,wasm}'`
+*Default:* `'**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf,wasm,json}'`
 
 ### fileIgnorePattern
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
       defaultConfig: {
-        filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf,wasm}',
+        filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf,wasm,json}',
         fileIgnorePattern: null,
         prefix: '',
         profile: '',

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -195,7 +195,7 @@ describe('s3 plugin', function() {
       plugin.beforeHook(context);
       plugin.configure(context);
 
-      assert.equal(context.config.s3.filePattern, '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf,wasm}');
+      assert.equal(context.config.s3.filePattern, '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,otf,wasm,json}');
       assert.equal(context.config.s3.prefix, '');
       assert.equal(context.config.s3.cacheControl, 'max-age=63072000, public');
       assert.equal(new Date(context.config.s3.expires).getTime(), new Date('Tue, 01 Jan 2030 00:00:00 GMT').getTime());


### PR DESCRIPTION
## What Changed & Why
Add .json to default `filePattern`. See #126 for motivation.

## Related issues
Closes #126

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

