### PR TITLE
Optionally ignore ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,13 @@ or Openstack Swift
 
 If `endpoint` set the `region` option will be ignored.
 
-*Default:* `[region].s3.amazonaws.com` 
+*Default:* `[region].s3.amazonaws.com`
 
 ### acl
 
 The ACL to apply to the objects.
+
+Set to `false` to not apply any ACLs.
 
 *Default:* `public-read`
 

--- a/index.js
+++ b/index.js
@@ -94,13 +94,16 @@ module.exports = {
           brotliCompressedFilePaths: brotliCompressedFiles,
           prefix: prefix,
           bucket: bucket,
-          acl: acl,
           manifestPath: manifestPath,
           cacheControl: cacheControl,
           expires: expires,
           batchSize: batchSize,
           defaultMimeType: defaultMimeType
         };
+
+        if (acl) {
+          options.acl = acl;
+        }
 
         if (serverSideEncryption) {
           options.serverSideEncryption = serverSideEncryption;

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -340,5 +340,22 @@ describe('s3 plugin', function() {
         done(reason);
       });
     });
+
+    it('does not add an ACL', function() {
+      context.config.s3.acl = false
+
+      var plugin = subject.createDeployPlugin({
+        name: 's3'
+      });
+
+      context.uploadClient.upload = function(options) {
+        return RSVP.resolve(options);
+      };
+      plugin.beforeHook(context);
+      return assert.isFulfilled(plugin.upload(context))
+        .then(function(options) {
+          assert.equal(options.acl, undefined, 'acl is not present');
+        });
+    });
   });
 });


### PR DESCRIPTION
## What Changed & Why
[Since April 2023, buckets by default have ACLs off](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/). This change allows ACLs to be ignored if set to `false`. This allows the plugin to work with the default bucket policy.

## Related issues
Link to related issues in this or other repositories (if any)

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]

## People
Mention people who would be interested in the changeset (if any)
