### PR TITLE
Fix setting of credentials via plugin config

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -46,8 +46,10 @@ module.exports = CoreObject.extend({
 
     if (accessKeyId && secretAccessKey) {
       this.plugin.log('Using AWS access key id and secret access key from config', { verbose: true });
-      s3Options.accessKeyId = accessKeyId;
-      s3Options.secretAccessKey = secretAccessKey;
+      s3Options.credentials = {
+        accessKeyId: accessKeyId,
+        secretAccessKey: secretAccessKey,
+      };
     }
 
     if (signatureVersion) {


### PR DESCRIPTION
I think AWS SDK v3 migration is broken, there may be other things that were missed. The credential setting definitely doesn't work.