### PR TITLE
Provide session token to credentials

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -50,16 +50,16 @@ module.exports = CoreObject.extend({
         accessKeyId: accessKeyId,
         secretAccessKey: secretAccessKey,
       };
+
+      if (sessionToken) {
+        this.plugin.log('Using AWS session token from config', { verbose: true });
+        s3Options.credentials.sessionToken = sessionToken;
+      }
     }
 
     if (signatureVersion) {
       this.plugin.log('Using signature version from config', { verbose: true });
       s3Options.signatureVersion = signatureVersion;
-    }
-
-    if (sessionToken) {
-      this.plugin.log('Using AWS session token from config', { verbose: true });
-      s3Options.sessionToken = sessionToken;
     }
 
     if (profile && !this.plugin.readConfig('s3Client')) {


### PR DESCRIPTION
This is a followup to #190, where `accessKeyId` and `secretAccessKey` were moved to the `credentials` object.

The optional `sessionToken` is also part of `credentials` object in [AWS SDK v3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-types/Interface/AwsCredentialIdentity/).

Fixes `The AWS Access Key Id you provided does not exist in our records.` error when using session token from STS service.