### PR TITLE
Add contributing guide & corepack support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Thank you for your interest in contributing to `ember-cli-deploy-s3`!
+
+## Getting Started
+
+To get started with development, please follow these steps:
+
+1. **Fork the repository** on GitHub.
+2. **Clone your fork** to your local machine:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/ember-cli-deploy-s3.git
+   ```
+3. **Install dependencies** by running:
+   ```bash
+   yarn
+   ```
+
+## Running Tests
+
+To run the tests for this project, you can use:
+```bash
+yarn test
+```
+
+## Submitting Pull Requests
+
+1. Create a new branch for your feature or bugfix.
+2. Commit your changes with clear and descriptive messages.
+3. Push your branch to your fork.
+4. Open a Pull Request from your branch to the main repository.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "volta": {
     "node": "16.20.0",
-    "yarn": "1.22.17"
-  }
+    "yarn": "1.22.22"
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Had Gemini 3 generate a simple CONTRIBUTING.md with steps on how to set up the repo and run tests.

Also had corepack add a `packageManager` entry for corepack support of the existing yarn.lock.

I bumped the yarn patch version in the volta config from 1.22.17 to 1.22.22 just to match what corepack happened to install. Figured it's an innocuous bump. But if 1.22.17 is desirable for some specific reason, I can figure out how to get corepack to pin that version instead.